### PR TITLE
Host front-end on Heroku

### DIFF
--- a/front-end/Dockerfile.web
+++ b/front-end/Dockerfile.web
@@ -1,0 +1,11 @@
+FROM node:16.14.0-alpine3.14
+
+WORKDIR /app
+COPY app/package.json .
+RUN npm install
+RUN npm ci --only=production
+COPY /app .
+
+EXPOSE 3000
+
+CMD ["npm", "start"]


### PR DESCRIPTION
I created a production Dockerfile (`Dockerfile.web`) in the front-end directory to specify how Heroku should build the React Docker container. It worked as expected and is currently hosted on Heroku at https://husky-reads-front-end.herokuapp.com. Automatic building when a push is made to the `production` branch has not been implemented yet. Accomplishes task 1 of 2 in issue #118 