### PR TITLE
130-131 Sync Up and Test Response Body Keys and Documentation

### DIFF
--- a/back-end/app/controllers/book_controller.js
+++ b/back-end/app/controllers/book_controller.js
@@ -23,8 +23,8 @@ exports.getMatchingBooks= async (info) => {
 	let genre = info.genre;
 
 	let params = [];
-	let query = `   SELECT Books.title AS title, Books.ISBN AS ISBN,
-                        GROUP_CONCAT(DISTINCT Authors.name SEPARATOR ',') AS author_names
+	let query = `   SELECT Books.title AS title, Books.ISBN AS isbn,
+                        GROUP_CONCAT(DISTINCT Authors.name SEPARATOR ',') AS authors
                     FROM Books
                     INNER JOIN Book_Authors
                         ON Books.ISBN = Book_Authors.ISBN_book
@@ -46,7 +46,7 @@ exports.getMatchingBooks= async (info) => {
 	}
 	query += "GROUP BY Books.title, Books.ISBN ";
 	if (author) {
-		query += "HAVING FIND_IN_SET(?, author_names)";
+		query += "HAVING FIND_IN_SET(?, authors)";
 		params.push(author);
 	}
 	query += `;`;

--- a/back-end/app/controllers/book_controller.js
+++ b/back-end/app/controllers/book_controller.js
@@ -61,7 +61,7 @@ exports.getMatchingBooks= async (info) => {
  */
 exports.getBookDetails = async (isbn) => {
     let query = `
-    SELECT Books.title AS title, Books.date_published AS date_published,
+    SELECT Books.title AS title, Books.date_published AS datePublished,
         Books.description AS description,
         GROUP_CONCAT(DISTINCT Authors.name SEPARATOR ',') AS authors,
         GROUP_CONCAT(DISTINCT Genres.name SEPARATOR ',') AS genres

--- a/back-end/app/routes/user_routes.js
+++ b/back-end/app/routes/user_routes.js
@@ -107,7 +107,7 @@ router.post("/color_scheme", async (req, res) => {
                 res.status(codes.CLIENT_ERROR_CODE_401).send("Invalid username");
             } else {
                 if (color_scheme != "light" && color_scheme != "dark") {
-                    res.status(codes.CLIENT_ERROR_CODE_400).send("Invalid Color Scheme");
+                    res.status(codes.CLIENT_ERROR_CODE_400).send("Invalid color scheme");
                 } else {
                     let info = [color_scheme, username];
                     await updateColorScheme(info);

--- a/back-end/app/tests/book/detail_book.test.js
+++ b/back-end/app/tests/book/detail_book.test.js
@@ -51,8 +51,8 @@ describe('GET /books/detail/:isbn', function() {
         res.body.should.be.an('object');
         res.body.should.have.property("title");
         res.body.title.should.be.eql("title1");
-        res.body.should.have.property("date_published");
-        res.body.date_published.should.be.eql("2020-12-01T08:00:00.000Z");
+        res.body.should.have.property("datePublished");
+        res.body.datePublished.should.be.eql("2020-12-01T08:00:00.000Z");
         res.body.should.have.property("description");
         res.body.description.should.be.eql("Long Description1");
         res.body.should.have.property("authors");
@@ -72,8 +72,8 @@ describe('GET /books/detail/:isbn', function() {
         res.body.should.be.an('object');
         res.body.should.have.property("title");
         res.body.title.should.be.eql("title5");
-        res.body.should.have.property("date_published");
-        res.body.date_published.should.be.eql("2020-12-05T08:00:00.000Z");
+        res.body.should.have.property("datePublished");
+        res.body.datePublished.should.be.eql("2020-12-05T08:00:00.000Z");
         res.body.should.have.property("description");
         res.body.description.should.be.eql("Long Description5");
         res.body.should.have.property("authors");

--- a/back-end/app/tests/book/search_book.test.js
+++ b/back-end/app/tests/book/search_book.test.js
@@ -27,6 +27,9 @@ describe('GET /books/search', function() {
       res.body.remainingBooksInSearch.should.be.eql(0);
       res.body.should.have.property("books");
       res.body.books.length.should.be.eql(5);
+      res.body.books[0].should.have.property("title");
+      res.body.books[0].should.have.property("authors");
+      res.body.books[0].should.have.property("isbn");
       done();
     });
   });
@@ -42,6 +45,9 @@ describe('GET /books/search', function() {
       res.body.remainingBooksInSearch.should.be.eql(0);
       res.body.should.have.property("books");
       res.body.books.length.should.be.eql(1);
+      res.body.books[0].should.have.property("title");
+      res.body.books[0].should.have.property("authors");
+      res.body.books[0].should.have.property("isbn");
       done();
     });
   });
@@ -57,6 +63,9 @@ describe('GET /books/search', function() {
       res.body.remainingBooksInSearch.should.be.eql(0);
       res.body.should.have.property("books");
       res.body.books.length.should.be.eql(3);
+      res.body.books[0].should.have.property("title");
+      res.body.books[0].should.have.property("authors");
+      res.body.books[0].should.have.property("isbn");
       done();
     });
   });
@@ -72,6 +81,9 @@ describe('GET /books/search', function() {
       res.body.remainingBooksInSearch.should.be.eql(0);
       res.body.should.have.property("books");
       res.body.books.length.should.be.eql(1);
+      res.body.books[0].should.have.property("title");
+      res.body.books[0].should.have.property("authors");
+      res.body.books[0].should.have.property("isbn");
       done();
     });
   });
@@ -87,6 +99,9 @@ describe('GET /books/search', function() {
       res.body.remainingBooksInSearch.should.be.eql(0);
       res.body.should.have.property("books");
       res.body.books.length.should.be.eql(1);
+      res.body.books[0].should.have.property("title");
+      res.body.books[0].should.have.property("authors");
+      res.body.books[0].should.have.property("isbn");
       done();
     });
   });
@@ -102,6 +117,9 @@ describe('GET /books/search', function() {
       res.body.remainingBooksInSearch.should.be.eql(0);
       res.body.should.have.property("books");
       res.body.books.length.should.be.eql(4);
+      res.body.books[0].should.have.property("title");
+      res.body.books[0].should.have.property("authors");
+      res.body.books[0].should.have.property("isbn");
       done();
     });
   });
@@ -117,6 +135,9 @@ describe('GET /books/search', function() {
       res.body.remainingBooksInSearch.should.be.eql(3);
       res.body.should.have.property("books");
       res.body.books.length.should.be.eql(2);
+      res.body.books[0].should.have.property("title");
+      res.body.books[0].should.have.property("authors");
+      res.body.books[0].should.have.property("isbn");
       done();
     });
   });
@@ -132,6 +153,9 @@ describe('GET /books/search', function() {
       res.body.remainingBooksInSearch.should.be.eql(2);
       res.body.should.have.property("books");
       res.body.books.length.should.be.eql(2);
+      res.body.books[0].should.have.property("title");
+      res.body.books[0].should.have.property("authors");
+      res.body.books[0].should.have.property("isbn");
       done();
     });
   });
@@ -147,6 +171,9 @@ describe('GET /books/search', function() {
       res.body.remainingBooksInSearch.should.be.eql(0);
       res.body.should.have.property("books");
       res.body.books.length.should.be.eql(1);
+      res.body.books[0].should.have.property("title");
+      res.body.books[0].should.have.property("authors");
+      res.body.books[0].should.have.property("isbn");
       done();
     });
   });
@@ -162,6 +189,9 @@ describe('GET /books/search', function() {
       res.body.remainingBooksInSearch.should.be.eql(0);
       res.body.should.have.property("books");
       res.body.books.length.should.be.eql(1);
+      res.body.books[0].should.have.property("title");
+      res.body.books[0].should.have.property("authors");
+      res.body.books[0].should.have.property("isbn");
       done();
     });
   });

--- a/back-end/app/tests/user/color_scheme.test.js
+++ b/back-end/app/tests/user/color_scheme.test.js
@@ -174,6 +174,21 @@ describe('POST /color_scheme', function() {
         })
     })
 
+    it('400: invalid color scheme', function(done) {
+        let user = {
+            username: "elliot",
+            color_scheme: "dark123"
+        }
+        chai.request(server)
+        .post('/color_scheme')
+        .send(user)
+        .end(function(err, res) {
+            res.should.have.status(400);
+            res.text.should.equal("Invalid color scheme")
+            done();
+        })
+    })
+
     it('401: invalid username and color_scheme', function(done) {
         let user = {
             username: "elliot123",


### PR DESCRIPTION
I examined all of the endpoints (excluding the cookie endpoints) and ensured that the error messages and the keys in the body of the responses returned exactly what the documentation specified. I found 3 endpoints (listed below) that were inconsistent with the documentation. At each place, the router's response was updated to match the exact error message in the documentation and so were the tests for that endpoint. Closes #130 and #131 

Endpoints that were changed:

- `/books/search`: `author_names` changed to `authors` and `ISBN` changed to `isbn`. Also added code in tests to check for this from now on.
- `/color_scheme`: Fixed the capitalization of the invalid color scheme error and created a test for it.
- `/books/detail/:isbn`: `date_published` changed to `datePublished`. The tests now look for this key.