### PR TITLE
148 update books primary key

### DIFF
--- a/back-end/API_Documentation/Books.md
+++ b/back-end/API_Documentation/Books.md
@@ -35,7 +35,7 @@ Returns a list of books that match given search parameters and the number of boo
             {
                 "title": "Hunger Games",
                 "authors": ["Suzanne Collins"],
-                "isbn": 2222222222
+                "isbn": "2222222222"
             }
         ]
     }
@@ -60,7 +60,7 @@ Returns a detailed description for a single book. The information returned consi
 
     | Name   | Type    | Description                                     |
     | -------| ------- | ----------------------------------------------- |
-    | `isbn` | Integer | The isbn number of the book to get details for. |
+    | `isbn` | String  | The isbn number of the book to get details for. |
 
 * **Returned Data Format:** JSON
 
@@ -91,5 +91,9 @@ Returns a detailed description for a single book. The information returned consi
 * **Notes:**
 
     * 2/14/22: Ratings and Reviews still under implementation
+
+    * 6/8/22: All ISBN's are now strings, not numbers. This change has been made to prevent the loss of the first digit if it is a 0.
+    
+    * 6/8/22: Date published dates vary in format
 
     </br>

--- a/back-end/API_Documentation/Bookshelves.md
+++ b/back-end/API_Documentation/Bookshelves.md
@@ -39,7 +39,7 @@ Returns a list of books that belong in a given user's bookshelf. If no bookshelf
             "name": "want_to_read",
             "books": [
                 {
-                    "isbn": 2222222222,
+                    "isbn": "2222222222",
                     "title": "Hunger Games",
                     "authors": ["Suzanne Collins"],
                     "genres": ["Young Adult", "Dystopian"]
@@ -68,7 +68,7 @@ Returns a list of books that belong in a given user's bookshelf. If no bookshelf
             "name": "want_to_read",
             "books": [
                 {
-                    "isbn": 1111111111,
+                    "isbn": "1111111111",
                     "title": "title1",
                     "authors": [
                         "Terrence Tao"
@@ -126,7 +126,7 @@ Adds a book to the specified bookshelf for a user.
     | ----------- | ------- | ------------------------------------------------ |
     | `username`  | String  | The username of the user who owns the bookshelf. |
     | `bookshelf` | String  | The name of the bookshelf to add a book to.      |
-    | `isbn`      | Integer | The isbn of the book to add to the bookshelf.    |
+    | `isbn`      | String  | The isbn of the book to add to the bookshelf.    |
 
 * **Returned Data Format:** Plain Text
 
@@ -174,7 +174,7 @@ Removes a book from a specified bookshelf for a user.
     | ----------- | ------- | --------------------------------------------------- |
     | `username`  | String  | The username of the user who owns the bookshelf.    |
     | `bookshelf` | String  | The name of the bookshelf to remove a book from.    |
-    | `isbn`      | Integer | The isbn of the book to remove from the bookshelf.  |
+    | `isbn`      | String  | The isbn of the book to remove from the bookshelf.  |
 
 * **Returned Data Format:** Plain Text
 
@@ -221,7 +221,7 @@ Returns a list of names of bookshelves for a user that contain a specific book. 
     | Name        | Type    | Description                                         |
     | ----------- | ------- | --------------------------------------------------- |
     | `username`  | String  | The username of the user who owns the bookshelves.  |
-    | `isbn`      | Integer | The isbn of the book to search for in bookshelves.  |
+    | `isbn`      | String  | The isbn of the book to search for in bookshelves.  |
 
 * **Returned Data Format:** JSON
 
@@ -255,4 +255,8 @@ Returns a list of names of bookshelves for a user that contain a specific book. 
     ```JSON
     {"error": "Invalid username parameter"}
     ```
+* **Notes:**
+
+    * 6/8/22: All ISBN's are now strings, not numbers. This change has been made to prevent the loss of the first digit if it is a 0.
+
     </br>

--- a/back-end/app/tests/book/detail_book.test.js
+++ b/back-end/app/tests/book/detail_book.test.js
@@ -83,4 +83,88 @@ describe('GET /books/detail/:isbn', function() {
       done();
     });
   });
+
+  it('200: valid ISBN 10 starting with 0', function(done) {
+    chai.request(server)
+    .get('/books/detail/0123456789')
+    .end(function(err, res) {
+        res.should.have.status(200);
+        res.should.be.json;
+        res.body.should.be.an('object');
+        res.body.should.have.property("title");
+        res.body.title.should.be.eql("title0");
+        res.body.should.have.property("datePublished");
+        res.body.datePublished.should.be.eql("2020-11-1");
+        res.body.should.have.property("description");
+        res.body.description.should.be.eql("Long Description0");
+        res.body.should.have.property("authors");
+        res.body.authors.length.should.be.eql(1)
+        res.body.should.have.property("genres");
+        res.body.genres.length.should.be.eql(1)
+        done();
+    });
+  });
+
+  it('200: valid ISBN 13 not starting with 0', function(done) {
+    chai.request(server)
+    .get('/books/detail/7777777777777')
+    .end(function(err, res) {
+        res.should.have.status(200);
+        res.should.be.json;
+        res.body.should.be.an('object');
+        res.body.should.have.property("title");
+        res.body.title.should.be.eql("title7");
+        res.body.should.have.property("datePublished");
+        res.body.datePublished.should.be.eql("2020-12-7");
+        res.body.should.have.property("description");
+        res.body.description.should.be.eql("Long Description7");
+        res.body.should.have.property("authors");
+        res.body.authors.length.should.be.eql(1)
+        res.body.should.have.property("genres");
+        res.body.genres.length.should.be.eql(1)
+        done();
+    });
+  });
+
+  it('200: valid ISBN 13 starting with 0', function(done) {
+    chai.request(server)
+    .get('/books/detail/0888888888888')
+    .end(function(err, res) {
+        res.should.have.status(200);
+        res.should.be.json;
+        res.body.should.be.an('object');
+        res.body.should.have.property("title");
+        res.body.title.should.be.eql("title8");
+        res.body.should.have.property("datePublished");
+        res.body.datePublished.should.be.eql("2020-12-8");
+        res.body.should.have.property("description");
+        res.body.description.should.be.eql("Long Description8");
+        res.body.should.have.property("authors");
+        res.body.authors.length.should.be.eql(1)
+        res.body.should.have.property("genres");
+        res.body.genres.length.should.be.eql(1)
+        done();
+    });
+  });
+
+  it('200: valid ISBN 13 containing existing ISBN 10 substring', function(done) {
+    chai.request(server)
+    .get('/books/detail/1111111111111')
+    .end(function(err, res) {
+        res.should.have.status(200);
+        res.should.be.json;
+        res.body.should.be.an('object');
+        res.body.should.have.property("title");
+        res.body.title.should.be.eql("title11");
+        res.body.should.have.property("datePublished");
+        res.body.datePublished.should.be.eql("2020-11-11");
+        res.body.should.have.property("description");
+        res.body.description.should.be.eql("Long Description11");
+        res.body.should.have.property("authors");
+        res.body.authors.length.should.be.eql(1)
+        res.body.should.have.property("genres");
+        res.body.genres.length.should.be.eql(1)
+        done();
+    });
+  });
 });

--- a/back-end/app/tests/book/detail_book.test.js
+++ b/back-end/app/tests/book/detail_book.test.js
@@ -42,7 +42,7 @@ describe('GET /books/detail/:isbn', function() {
     });
   });
 
-  it('200: valid isbn', function(done) {
+  it('200: valid isbn not starting with 0', function(done) {
     chai.request(server)
     .get('/books/detail/1111111111')
     .end(function(err, res) {
@@ -52,7 +52,7 @@ describe('GET /books/detail/:isbn', function() {
         res.body.should.have.property("title");
         res.body.title.should.be.eql("title1");
         res.body.should.have.property("datePublished");
-        res.body.datePublished.should.be.eql("2020-12-01T08:00:00.000Z");
+        res.body.datePublished.should.be.eql("2020-12-1");
         res.body.should.have.property("description");
         res.body.description.should.be.eql("Long Description1");
         res.body.should.have.property("authors");
@@ -63,7 +63,7 @@ describe('GET /books/detail/:isbn', function() {
     });
   });
 
-  it('200: valid isbn (again)', function(done) {
+  it('200: valid isbn not starting with 0(again)', function(done) {
     chai.request(server)
     .get('/books/detail/5555555555')
     .end(function(err, res) {
@@ -73,7 +73,7 @@ describe('GET /books/detail/:isbn', function() {
         res.body.should.have.property("title");
         res.body.title.should.be.eql("title5");
         res.body.should.have.property("datePublished");
-        res.body.datePublished.should.be.eql("2020-12-05T08:00:00.000Z");
+        res.body.datePublished.should.be.eql("2020-12-5");
         res.body.should.have.property("description");
         res.body.description.should.be.eql("Long Description5");
         res.body.should.have.property("authors");

--- a/back-end/app/tests/book/search_book.test.js
+++ b/back-end/app/tests/book/search_book.test.js
@@ -26,7 +26,7 @@ describe('GET /books/search', function() {
       res.body.should.have.property("remainingBooksInSearch");
       res.body.remainingBooksInSearch.should.be.eql(0);
       res.body.should.have.property("books");
-      res.body.books.length.should.be.eql(5);
+      res.body.books.length.should.be.eql(9);
       res.body.books[0].should.have.property("title");
       res.body.books[0].should.have.property("authors");
       res.body.books[0].should.have.property("isbn");
@@ -116,7 +116,7 @@ describe('GET /books/search', function() {
       res.body.should.have.property("remainingBooksInSearch");
       res.body.remainingBooksInSearch.should.be.eql(0);
       res.body.should.have.property("books");
-      res.body.books.length.should.be.eql(4);
+      res.body.books.length.should.be.eql(8);
       res.body.books[0].should.have.property("title");
       res.body.books[0].should.have.property("authors");
       res.body.books[0].should.have.property("isbn");
@@ -132,7 +132,7 @@ describe('GET /books/search', function() {
       res.should.be.json;
       res.body.should.be.an('object');
       res.body.should.have.property("remainingBooksInSearch");
-      res.body.remainingBooksInSearch.should.be.eql(3);
+      res.body.remainingBooksInSearch.should.be.eql(7);
       res.body.should.have.property("books");
       res.body.books.length.should.be.eql(2);
       res.body.books[0].should.have.property("title");
@@ -150,7 +150,7 @@ describe('GET /books/search', function() {
       res.should.be.json;
       res.body.should.be.an('object');
       res.body.should.have.property("remainingBooksInSearch");
-      res.body.remainingBooksInSearch.should.be.eql(2);
+      res.body.remainingBooksInSearch.should.be.eql(6);
       res.body.should.have.property("books");
       res.body.books.length.should.be.eql(2);
       res.body.books[0].should.have.property("title");

--- a/back-end/app/tests/bookshelf/book_bookshelf.test.js
+++ b/back-end/app/tests/bookshelf/book_bookshelf.test.js
@@ -121,8 +121,8 @@ describe('GET /bookshelves/book/:username/:isbn', function() {
         .end(function(err, res) {
             res.should.have.status(200);
             res.body.length.should.be.eql(2);
-            res.body[0].should.be.eql("reading");
-            res.body[1].should.be.eql("read");
+            res.body.should.include("read");
+            res.body.should.include("reading");
             done();
         });
     });
@@ -133,9 +133,9 @@ describe('GET /bookshelves/book/:username/:isbn', function() {
         .end(function(err, res) {
             res.should.have.status(200);
             res.body.length.should.be.eql(3);
-            res.body[0].should.be.eql("want_to_read");
-            res.body[1].should.be.eql("read");
-            res.body[2].should.be.eql("reading");
+            res.body.should.include("want_to_read");
+            res.body.should.include("read");
+            res.body.should.include("reading");
             done();
         });
     });

--- a/back-end/app/tests/bookshelf/get_bookshelf.test.js
+++ b/back-end/app/tests/bookshelf/get_bookshelf.test.js
@@ -49,7 +49,7 @@ describe('GET /bookshelves/get/:username/:bookshelf', function() {
         res.body[0].books.length.should.be.eql(2);
         res.body[0].books[0].should.be.an('object');
         res.body[0].books[0].should.have.property("isbn");
-        res.body[0].books[0].isbn.should.be.eql(1111111111);
+        res.body[0].books[0].isbn.should.be.eql('1111111111');
         res.body[0].books[0].should.have.property("title");
         res.body[0].books[0].title.should.be.eql("title1");
         res.body[0].books[0].should.have.property("authors");
@@ -58,7 +58,7 @@ describe('GET /bookshelves/get/:username/:bookshelf', function() {
         res.body[0].books[0].genres.length.should.be.eql(1);
         res.body[0].books[1].should.be.an('object');
         res.body[0].books[1].should.have.property("isbn");
-        res.body[0].books[1].isbn.should.be.eql(2222222222);
+        res.body[0].books[1].isbn.should.be.eql('2222222222');
         res.body[0].books[1].should.have.property("title");
         res.body[0].books[1].title.should.be.eql("title2");
         res.body[0].books[1].should.have.property("authors");
@@ -83,7 +83,7 @@ describe('GET /bookshelves/get/:username/:bookshelf', function() {
         res.body[1].books.length.should.be.eql(1);
         res.body[1].books[0].should.be.an('object');
         res.body[1].books[0].should.have.property("isbn");
-        res.body[1].books[0].isbn.should.be.eql(1111111111);
+        res.body[1].books[0].isbn.should.be.eql('1111111111');
         res.body[1].books[0].should.have.property("title");
         res.body[1].books[0].title.should.be.eql("title1");
         res.body[1].books[0].should.have.property("authors");
@@ -97,7 +97,7 @@ describe('GET /bookshelves/get/:username/:bookshelf', function() {
         res.body[0].books.length.should.be.eql(2);
         res.body[0].books[0].should.be.an('object');
         res.body[0].books[0].should.have.property("isbn");
-        res.body[0].books[0].isbn.should.be.eql(1111111111);
+        res.body[0].books[0].isbn.should.be.eql('1111111111');
         res.body[0].books[0].should.have.property("title");
         res.body[0].books[0].title.should.be.eql("title1");
         res.body[0].books[0].should.have.property("authors");
@@ -106,7 +106,7 @@ describe('GET /bookshelves/get/:username/:bookshelf', function() {
         res.body[0].books[0].genres.length.should.be.eql(1);
         res.body[0].books[1].should.be.an('object');
         res.body[0].books[1].should.have.property("isbn");
-        res.body[0].books[1].isbn.should.be.eql(2222222222);
+        res.body[0].books[1].isbn.should.be.eql('2222222222');
         res.body[0].books[1].should.have.property("title");
         res.body[0].books[1].title.should.be.eql("title2");
         res.body[0].books[1].should.have.property("authors");

--- a/back-end/app/tests/resetdb.sql
+++ b/back-end/app/tests/resetdb.sql
@@ -18,7 +18,7 @@ CREATE TABLE Users (
 );
 
 CREATE TABLE Books (
-  ISBN bigint UNIQUE PRIMARY KEY,
+  ISBN char(13) UNIQUE PRIMARY KEY,
   title varchar(255) NOT NULL,
   description TEXT,
   date_published date
@@ -41,7 +41,7 @@ CREATE TABLE Bookshelves (
 
 CREATE TABLE Bookshelf_Books (
     id_bookshelf int,
-    ISBN bigint NOT NULL,
+    ISBN char(13) NOT NULL,
     /* Constraint: If a bookshelf is deleted, delete the bookshelf's book connections */
     CONSTRAINT SHELFDELETE
     FOREIGN KEY (id_bookshelf)
@@ -66,7 +66,7 @@ CREATE TABLE Genres (
 );
 
 CREATE TABLE Book_Authors (
-  ISBN_book bigint NOT NULL,
+  ISBN_book char(13) NOT NULL,
   id_author int NOT NULL REFERENCES Authors(id),
   /* Constraint: If a book is deleted, also delete book's author connections */
   CONSTRAINT REFBOOK
@@ -76,7 +76,7 @@ CREATE TABLE Book_Authors (
 );
 
 CREATE TABLE Book_Genres (
-  ISBN_book bigint NOT NULL,
+  ISBN_book char(13) NOT NULL,
   id_genre int NOT NULL REFERENCES Genres(id),
   /* Constraint: If a book is deleted, also delete the book's genre connections */
   FOREIGN KEY (ISBN_BOOK)
@@ -94,12 +94,12 @@ SET auto_increment_offset = 1;
 /* SAMPLE DATA */
 
 INSERT INTO Books (ISBN, title, description, date_published) VALUES
-    (1111111111, "title1", "Long Description1", '2020--12-1'),
-    (2222222222, "title2", "Long Description2", '2020--12-2'),
-    (3333333333, "title3", "Long Description3", '2020--12-3'),
-    (4444444444, "title4", "Long Description4", '2020--12-4'),
-    (5555555555, "title5", "Long Description5", '2020--12-5'),
-    (6666666666, "title6", "Long Description6", '2020--12-6')
+    ('1111111111', "title1", "Long Description1", '2020-12-1'),
+    ('2222222222', "title2", "Long Description2", '2020-12-2'),
+    ('3333333333', "title3", "Long Description3", '2020-12-3'),
+    ('4444444444', "title4", "Long Description4", '2020-12-4'),
+    ('5555555555', "title5", "Long Description5", '2020-12-5'),
+    ('6666666666', "title6", "Long Description6", '2020-12-6'),
 ;
 
 
@@ -122,21 +122,21 @@ INSERT INTO Genres (name) VALUES
 ;
 
 INSERT INTO Book_Authors (ISBN_book, id_author) VALUES
-    (1111111111, 1),
-    (2222222222, 2),
-    (3333333333, 3),
-    (4444444444, 3), /* Edge Case */
-    (5555555555, 4), /* Edge Case */
-    (5555555555, 3)  /* Edge Case */
+    ('1111111111', 1),
+    ('2222222222', 2),
+    ('3333333333', 3),
+    ('4444444444', 3), /* Edge Case */
+    ('5555555555', 4), /* Edge Case */
+    ('5555555555', 3),  /* Edge Case */
 ;
 
 INSERT INTO Book_Genres (ISBN_book, id_genre) VALUES
-    (1111111111, 1),
-    (2222222222, 2),
-    (3333333333, 3),
-    (4444444444, 3), /* Edge Case */
-    (5555555555, 5), /* Edge Case */
-    (5555555555, 4)  /* Edge Case */
+    ('1111111111', 1),
+    ('2222222222', 2),
+    ('3333333333', 3),
+    ('4444444444', 3), /* Edge Case */
+    ('5555555555', 5), /* Edge Case */
+    ('5555555555', 4), /* Edge Case */
 ;
 
 /* RUN DELETE STATEMENTS SEPARATELY IF DOING TESTING */

--- a/back-end/app/tests/resetdb.sql
+++ b/back-end/app/tests/resetdb.sql
@@ -21,7 +21,24 @@ CREATE TABLE Books (
   ISBN char(13) UNIQUE PRIMARY KEY,
   title varchar(255) NOT NULL,
   description TEXT,
-  date_published date
+  date_published varchar(100)
+);
+
+CREATE TABLE Reviews (
+  id_review int PRIMARY KEY AUTO_INCREMENT,
+  ISBN_book char(13) NOT NULL REFERENCES Books(ISBN),
+  id_user int NOT NULL,
+  content varchar(255),
+  published date NOT NULL,
+  CONSTRAINT USERDELETED
+  FOREIGN KEY (id_user)
+  REFERENCES Users(id)
+    ON DELETE CASCADE,
+  /* Constraint: If a book is deleted, also delete the book's related reviews */
+  CONSTRAINT BOOKDELETED
+  FOREIGN KEY (ISBN_book)
+  REFERENCES Books(ISBN)
+    ON DELETE CASCADE
 );
 
 /* Default per user, insert:
@@ -56,7 +73,7 @@ CREATE TABLE Bookshelf_Books (
 );
 
 CREATE TABLE Authors (
-  id int PRIMARY KEY AUTO_INCREMENT,
+  id varchar(40) NOT NULL,
   name varchar(255) NOT NULL
 );
 
@@ -67,8 +84,8 @@ CREATE TABLE Genres (
 
 CREATE TABLE Book_Authors (
   ISBN_book char(13) NOT NULL,
-  id_author int NOT NULL REFERENCES Authors(id),
-  /* Constraint: If a book is deleted, also delete book's author connections */
+  id_author varchar(40) REFERENCES Authors(id),
+  /* Constraint: If a book is deleted, also delete book's related authors */
   CONSTRAINT REFBOOK
   FOREIGN KEY (ISBN_book)
   REFERENCES Books(ISBN)
@@ -79,7 +96,7 @@ CREATE TABLE Book_Genres (
   ISBN_book char(13) NOT NULL,
   id_genre int NOT NULL REFERENCES Genres(id),
   /* Constraint: If a book is deleted, also delete the book's genre connections */
-  FOREIGN KEY (ISBN_BOOK)
+  FOREIGN KEY (ISBN_book)
   REFERENCES Books(ISBN)
     ON DELETE CASCADE
 );
@@ -92,25 +109,28 @@ SET auto_increment_offset = 1;
 
 
 /* SAMPLE DATA */
-
 INSERT INTO Books (ISBN, title, description, date_published) VALUES
+    ('0123456789', "title0", "Long Description0", '2020-11-1'),
     ('1111111111', "title1", "Long Description1", '2020-12-1'),
     ('2222222222', "title2", "Long Description2", '2020-12-2'),
     ('3333333333', "title3", "Long Description3", '2020-12-3'),
     ('4444444444', "title4", "Long Description4", '2020-12-4'),
     ('5555555555', "title5", "Long Description5", '2020-12-5'),
     ('6666666666', "title6", "Long Description6", '2020-12-6'),
+    ('1111111111111', "title11", "Long Description11", '2020-11-11'),
+    ('7777777777777', "title7", "Long Description7", '2020-12-7'),
+    ('0888888888888', "title8", "Long Description8", '2020-12-8')
 ;
 
-
-INSERT INTO Authors (name) VALUES
-    ("Terrence Tao"),
-    ("Brett Wortmanz"),
-    ("Foo Bar the Third"),
-    ("Suzzy Collins"),
-    ("Albert Einstein"),
-    ("李涛"),                           /* Testing non-latin characters */
-    ("Александр Сергеевич Пушкин")      /* Testing non-latin characters */
+INSERT INTO Authors (id, name) VALUES
+    (1, "Terrence Tao"),
+    (2, "Brett Wortmanz"),
+    (3, "Foo Bar the Third"),
+    (4, "Suzzy Collins"),
+    (5, "Albert Einstein"),
+    (6, "李涛"),                           /* Testing non-latin characters */
+    (7, "Александр Сергеевич Пушкин"),    /* Testing non-latin characters */
+    (8, "John Snow")
 ;
 
 INSERT INTO Genres (name) VALUES
@@ -118,7 +138,8 @@ INSERT INTO Genres (name) VALUES
     ("Romance"),
     ("Action"),
     ("Young Adult"),
-    ("Thriller")
+    ("Thriller"),
+    ("Fake Genre")
 ;
 
 INSERT INTO Book_Authors (ISBN_book, id_author) VALUES
@@ -128,6 +149,10 @@ INSERT INTO Book_Authors (ISBN_book, id_author) VALUES
     ('4444444444', 3), /* Edge Case */
     ('5555555555', 4), /* Edge Case */
     ('5555555555', 3),  /* Edge Case */
+    ('0123456789', 8),
+    ('1111111111111', 8),
+    ('7777777777777', 8),
+    ('0888888888888', 8)
 ;
 
 INSERT INTO Book_Genres (ISBN_book, id_genre) VALUES
@@ -137,6 +162,11 @@ INSERT INTO Book_Genres (ISBN_book, id_genre) VALUES
     ('4444444444', 3), /* Edge Case */
     ('5555555555', 5), /* Edge Case */
     ('5555555555', 4), /* Edge Case */
+    ('0123456789', 6),
+    ('1111111111111', 6),
+    ('7777777777777', 6),
+    ('0888888888888', 6)
+
 ;
 
 /* RUN DELETE STATEMENTS SEPARATELY IF DOING TESTING */

--- a/back-end/scripts/database.sql
+++ b/back-end/scripts/database.sql
@@ -120,16 +120,16 @@ INSERT INTO Users (username, password) VALUES
 ;
 
 INSERT INTO Books (ISBN, title, description, date_published) VALUES
-    ('0123456789', "title0", "Long Description0", '2020--11-1'),
+    ('0123456789', "title0", "Long Description0", '2020-11-1'),
     ('1111111111', "title1", "Long Description1", '2020-12-1'),
     ('2222222222', "title2", "Long Description2", '2020-12-2'),
     ('3333333333', "title3", "Long Description3", '2020-12-3'),
     ('4444444444', "title4", "Long Description4", '2020-12-4'),
     ('5555555555', "title5", "Long Description5", '2020-12-5'),
     ('6666666666', "title6", "Long Description6", '2020-12-6'),
-    ('1111111111111', "title11", "Long Description11", '2020--11-11'),
-    ('7777777777777', "title7", "Long Description7", '2020--12-7'),
-    ('0888888888888', "title8", "Long Description8", '2020--12-8')
+    ('1111111111111', "title11", "Long Description11", '2020-11-11'),
+    ('7777777777777', "title7", "Long Description7", '2020-12-7'),
+    ('0888888888888', "title8", "Long Description8", '2020-12-8')
 ;
 
 INSERT INTO Reviews (ISBN_book, id_user, content, published) VALUES

--- a/back-end/scripts/database.sql
+++ b/back-end/scripts/database.sql
@@ -120,17 +120,21 @@ INSERT INTO Users (username, password) VALUES
 ;
 
 INSERT INTO Books (ISBN, title, description, date_published) VALUES
-    (1111111111, "title1", "Long Description1", '2020--12-1'),
-    (2222222222, "title2", "Long Description2", '2020--12-2'),
-    (3333333333, "title3", "Long Description3", '2020--12-3'),
-    (4444444444, "title4", "Long Description4", '2020--12-4'),
-    (5555555555, "title5", "Long Description5", '2020--12-5'),
-    (6666666666, "title6", "Long Description6", '2020--12-6')
+    ('0123456789', "title0", "Long Description0", '2020--11-1'),
+    ('1111111111', "title1", "Long Description1", '2020--12-1'),
+    ('2222222222', "title2", "Long Description2", '2020--12-2'),
+    ('3333333333', "title3", "Long Description3", '2020--12-3'),
+    ('4444444444', "title4", "Long Description4", '2020--12-4'),
+    ('5555555555', "title5", "Long Description5", '2020--12-5'),
+    ('6666666666', "title6", "Long Description6", '2020--12-6'),
+    ('1111111111111', "title11", "Long Description11", '2020--11-11'),
+    ('7777777777777', "title7", "Long Description7", '2020--12-7'),
+    ('0888888888888', "title8", "Long Description8", '2020--12-8')
 ;
 
 INSERT INTO Reviews (ISBN_book, id_user, content, published) VALUES
-    (1111111111, 1, "wow not that bad", CURDATE()),  /* CURDATE() puts in current date */
-    (2222222222, 2, "interesting book!", CURDATE())
+    ('1111111111', 1, "wow not that bad", CURDATE()),  /* CURDATE() puts in current date */
+    ('2222222222', 2, "interesting book!", CURDATE())
 ;
 
 INSERT INTO Bookshelves (id_user, shelf_name) VALUES
@@ -155,13 +159,13 @@ INSERT INTO Bookshelves (id_user, shelf_name) VALUES
 ;
 
 INSERT INTO Bookshelf_Books (id_bookshelf, ISBN) VALUES
-    (1, 1111111111),
-    (2, 1111111111),
-    (1, 2222222222),
-    (3, 3333333333),
-    (1, 4444444444),
-    (6, 5555555555),
-    (9, 1111111111)
+    (1, '1111111111'),
+    (2, '1111111111'),
+    (1, '2222222222'),
+    (3, '3333333333'),
+    (1, '4444444444'),
+    (6, '5555555555'),
+    (9, '1111111111')
 ;
 
 INSERT INTO Authors (id, name) VALUES
@@ -171,7 +175,8 @@ INSERT INTO Authors (id, name) VALUES
     (4, "Suzzy Collins"),
     (5, "Albert Einstein"),
     (6, "李涛"),                           /* Testing non-latin characters */
-    (7, "Александр Сергеевич Пушкин")      /* Testing non-latin characters */
+    (7, "Александр Сергеевич Пушкин"),    /* Testing non-latin characters */
+    (8, "John Snow")
 ;
 
 INSERT INTO Genres (name) VALUES
@@ -179,25 +184,35 @@ INSERT INTO Genres (name) VALUES
     ("Romance"),
     ("Action"),
     ("Young Adult"),
-    ("Thriller")
+    ("Thriller"),
+    ("Fake Genre")
 ;
 
 INSERT INTO Book_Authors (ISBN_book, id_author) VALUES
-    (1111111111, 1),
-    (2222222222, 2),
-    (3333333333, 3),
-    (4444444444, 3), /* Edge Case */
-    (5555555555, 4), /* Edge Case */
-    (5555555555, 3)  /* Edge Case */
+    ('1111111111', 1),
+    ('2222222222', 2),
+    ('3333333333', 3),
+    ('4444444444', 3), /* Edge Case */
+    ('5555555555', 4), /* Edge Case */
+    ('5555555555', 3),  /* Edge Case */
+    ('0123456789', 8),
+    ('1111111111111', 8),
+    ('7777777777777', 8),
+    ('0888888888888', 8)
 ;
 
 INSERT INTO Book_Genres (ISBN_book, id_genre) VALUES
-    (1111111111, 1),
-    (2222222222, 2),
-    (3333333333, 3),
-    (4444444444, 3), /* Edge Case */
-    (5555555555, 5), /* Edge Case */
-    (5555555555, 4)  /* Edge Case */
+    ('1111111111', 1),
+    ('2222222222', 2),
+    ('3333333333', 3),
+    ('4444444444', 3), /* Edge Case */
+    ('5555555555', 5), /* Edge Case */
+    ('5555555555', 4), /* Edge Case */
+    ('0123456789', 6),
+    ('1111111111111', 6),
+    ('7777777777777', 6),
+    ('0888888888888', 6)
+
 ;
 
 /* RUN DELETE STATEMENTS SEPARATELY IF DOING TESTING */

--- a/back-end/scripts/database.sql
+++ b/back-end/scripts/database.sql
@@ -18,7 +18,7 @@ CREATE TABLE Users (
 );
 
 CREATE TABLE Books (
-  ISBN bigint UNIQUE PRIMARY KEY,
+  ISBN char(13) UNIQUE PRIMARY KEY,
   title varchar(255) NOT NULL,
   description TEXT,
   date_published varchar(100)
@@ -26,7 +26,7 @@ CREATE TABLE Books (
 
 CREATE TABLE Reviews (
   id_review int PRIMARY KEY AUTO_INCREMENT,
-  ISBN_book bigint NOT NULL REFERENCES Books(ISBN),
+  ISBN_book char(13) NOT NULL REFERENCES Books(ISBN),
   id_user int NOT NULL,
   content varchar(255),
   published date NOT NULL,
@@ -58,7 +58,7 @@ CREATE TABLE Bookshelves (
 
 CREATE TABLE Bookshelf_Books (
     id_bookshelf int,
-    ISBN bigint NOT NULL,
+    ISBN char(13) NOT NULL,
     /* Constraint: If a bookshelf is deleted, delete the bookshelf's book connections */
     CONSTRAINT SHELFDELETE
     FOREIGN KEY (id_bookshelf)
@@ -83,7 +83,7 @@ CREATE TABLE Genres (
  );
 
 CREATE TABLE Book_Authors (
-  ISBN_book bigint NOT NULL,
+  ISBN_book char(13) NOT NULL,
   id_author varchar(40) REFERENCES Authors(id),
   /* Constraint: If a book is deleted, also delete book's related authors */
   CONSTRAINT REFBOOK
@@ -93,7 +93,7 @@ CREATE TABLE Book_Authors (
 );
 
 CREATE TABLE Book_Genres (
-  ISBN_book bigint NOT NULL,
+  ISBN_book char(13) NOT NULL,
   id_genre int NOT NULL REFERENCES Genres(id),
   /* Constraint: If a book is deleted, also delete the book's genre connections */
   FOREIGN KEY (ISBN_book)

--- a/back-end/scripts/database.sql
+++ b/back-end/scripts/database.sql
@@ -121,12 +121,12 @@ INSERT INTO Users (username, password) VALUES
 
 INSERT INTO Books (ISBN, title, description, date_published) VALUES
     ('0123456789', "title0", "Long Description0", '2020--11-1'),
-    ('1111111111', "title1", "Long Description1", '2020--12-1'),
-    ('2222222222', "title2", "Long Description2", '2020--12-2'),
-    ('3333333333', "title3", "Long Description3", '2020--12-3'),
-    ('4444444444', "title4", "Long Description4", '2020--12-4'),
-    ('5555555555', "title5", "Long Description5", '2020--12-5'),
-    ('6666666666', "title6", "Long Description6", '2020--12-6'),
+    ('1111111111', "title1", "Long Description1", '2020-12-1'),
+    ('2222222222', "title2", "Long Description2", '2020-12-2'),
+    ('3333333333', "title3", "Long Description3", '2020-12-3'),
+    ('4444444444', "title4", "Long Description4", '2020-12-4'),
+    ('5555555555', "title5", "Long Description5", '2020-12-5'),
+    ('6666666666', "title6", "Long Description6", '2020-12-6'),
     ('1111111111111', "title11", "Long Description11", '2020--11-11'),
     ('7777777777777', "title7", "Long Description7", '2020--12-7'),
     ('0888888888888', "title8", "Long Description8", '2020--12-8')


### PR DESCRIPTION
This pull request has changed the data type of book ISBNs from `bigint` to `char(13)`. This is because ISBNs can begin with zeros and that zero is dropped when saving the ISBN as a number. Subsequently, the ISBN will be sent to the front-end as a string and the documentation reflects these changes. In addition to changing the ISBN data type, I have added and fixed some tests for multiple endpoints. The new tests check both 10 and 13 digit ISBNs as well as ISBNs with and without a starting zero digit. Some minor fixes were made to pre-existing tests to address other recent changes to the database (made in prior pull requests). 

The only other thing to note is that the published date for books will be passed to the user in whatever format the data source provides them. This means that there will be many different formats used for this data and that the front-end should not assume anything about the format of the date data.

Closes #148 