### PR TITLE
141 import author demo data

### DIFF
--- a/back-end/scripts/database.sql
+++ b/back-end/scripts/database.sql
@@ -73,7 +73,7 @@ CREATE TABLE Bookshelf_Books (
 );
 
 CREATE TABLE Authors (
-  id varchar(40) NOT NULL,
+  id varchar(40) PRIMARY KEY,
   name varchar(255) NOT NULL
 );
 

--- a/back-end/scripts/importAuthors.py
+++ b/back-end/scripts/importAuthors.py
@@ -1,0 +1,113 @@
+import json
+import mysql.connector
+from mysql.connector import errorcode
+import requests
+
+CONFIG = {
+  'user': 'root',
+  'password': 'root',
+  'host': '127.0.0.1',
+  'database': 'huskyreads',
+  'port': 2000,     # MAKE SURE THIS PORT ALIGNS WITH YOUR PORT IN THE .env FILE
+  'raise_on_warnings': True
+}
+
+def connectToDatabase():
+    """ Creates connection to the MySQL Database
+
+    Returns:
+        The database connection object
+    """
+    try:
+        cnx = mysql.connector.connect(**CONFIG)
+        return cnx
+    except mysql.connector.Error as err:
+        if err.errno == errorcode.ER_ACCESS_DENIED_ERROR:
+            print("Something is wrong with your user name or password")
+        elif err.errno == errorcode.ER_BAD_DB_ERROR:
+            print("Database does not exist")
+        else:
+            print(err)
+
+def retrieveAuthorIds(filePath: str):
+    """ Retrieves unique author ids for authors who wrote the books in the provided file
+
+        Args:
+            filePath:
+                The file-path to the JSON file containing the data
+
+        Expected:
+            JSON file to contain field "data", with value [arr] where each indice contains book data
+
+        Returns:
+            Set of author ids
+    """
+    f = open(filePath)
+    data = json.load(f)
+    # Assumes data field is called "data" - this is controlled by the data modifying code
+    authorIds = set()
+    for book in data["data"]:
+        author = book.get("authors")
+        if author:
+            author = author[0].get("key").split("/")[2]
+            authorIds.add(author)
+
+    f.close()
+    return authorIds
+
+def getAuthorData(authorIds: set):
+    """ Gets data for each author from the Open Library Authors API
+
+        Args:
+            authorIds:
+                A set containing author ids
+
+        Returns:
+            A list of author data objects.
+            Author data is in the format: {"id": author_id, "name": author_name}
+    """
+    authors = list()
+    for authorId in authorIds:
+        response = requests.get(f'https://openlibrary.org/authors/{authorId}.json')
+        if response.status_code == requests.codes.ok:
+            responseBody = response.json()
+            authorName = responseBody.get("name")
+            author = {"id": authorId, "name": authorName}
+            authors.append(author)
+        else:
+            print(f'error getting author: {authorId}')
+            print(f'request HTTP code: {response.status_code}')
+    return authors
+
+def importAuthorData(authors: list, cnx: object):
+    """ Imports author data into the Author Table
+
+        Args:
+            authorsData:
+                List of Authors
+            cnx:
+                The connection object to the database
+        Expected:
+            Each element of authors list is a dictionary with format {"id": author_id, "name": author_name}
+            author_id, author_name expected to be strings
+    """
+    cursor = cnx.cursor()
+    for author in authors:
+        query = "INSERT INTO Authors (id, name) VALUES (%s, %s)"
+        placeholders = (author['id'], author['name'])
+        cursor.execute(query, placeholders)
+    cnx.commit()
+    cursor.close()
+
+def main():
+    file_path_books = "../data/processed/sample_data.json"
+    authorIds = retrieveAuthorIds(file_path_books)
+    authors = getAuthorData(authorIds)
+    cnx = connectToDatabase()
+    print("Connection Successful!")
+    importAuthorData(authors, cnx)
+    print("Data import successful! Please refresh database")
+    cnx.close()
+
+if __name__ == '__main__':
+    main()

--- a/back-end/scripts/importAuthors.py
+++ b/back-end/scripts/importAuthors.py
@@ -107,7 +107,6 @@ def main():
     print("Connection Successful!")
     importAuthorData(authorsData, cnx)
     print("Data import successful! Please refresh database")
-    print(authorIds)
     cnx.close()
 
 if __name__ == '__main__':

--- a/back-end/scripts/importAuthors.py
+++ b/back-end/scripts/importAuthors.py
@@ -47,11 +47,11 @@ def retrieveAuthorIds(filePath: str):
     # Assumes data field is called "data" - this is controlled by the data modifying code
     authorIds = set()
     for book in data["data"]:
-        author = book.get("authors")
-        if author:
-            author = author[0].get("key").split("/")[2]
-            authorIds.add(author)
-
+        authors = book.get("authors")
+        if authors:
+            for author in authors:
+                authorId = author.get("key").split("/")[2]
+                authorIds.add(authorId)
     f.close()
     return authorIds
 
@@ -102,11 +102,12 @@ def importAuthorData(authors: list, cnx: object):
 def main():
     file_path_books = "../data/processed/sample_data.json"
     authorIds = retrieveAuthorIds(file_path_books)
-    authors = getAuthorData(authorIds)
+    authorsData = getAuthorData(authorIds)
     cnx = connectToDatabase()
     print("Connection Successful!")
-    importAuthorData(authors, cnx)
+    importAuthorData(authorsData, cnx)
     print("Data import successful! Please refresh database")
+    print(authorIds)
     cnx.close()
 
 if __name__ == '__main__':

--- a/back-end/scripts/importInstructions.md
+++ b/back-end/scripts/importInstructions.md
@@ -3,27 +3,41 @@
 ### Step 1: Download raw book data
 
 1.1) Go to [Open Library's data dump page](https://openlibrary.org/developers/dumps) and download the **works dump**
+
 1.2) Unzip the file if it zipped
-<!-- DELETE THI S1.2) Place the file into `/HuskyReads/back-end/data/raw` and unzip it if it is zipped -->
 
 ### Step 2: Clean book Data
+
 2.1) Open the file `/HuskyReads/back-end/scripts/convertFileToCSV.py`
+
 2.2) Replace the text `INPUT_FILE_PATH` with the absolute path to the text file from step 1
+
 2.3) Replace the text `OUTPUT_FILE_PATH` with the absolute path of the file you would like to write to. This file should be placed into the folder `HuskyReads/back-end/data/raw`
+
 **Note:** Make sure a file with the path `OUTPUT_FILE_PATH` doesn't already exist.
+
 2.4) Open a command line/terminal window and change your current directory to the `/HuskyReads/back-end/scripts` directory
+
 2.4) Run the `convertFileToCSV.py` script with the command `python3 convertFileToCSV.py`
 
 ### Step 3: Turn the book data into JSON
+
 3.1) Run the `createJsonFile.py` script with the command `python3 createJsonFile.py`
 
 ### Step 4: Import the JSON book data in the database
+
 4.1) Open the file `/HuskyReads/back-end/scripts/importJsonToDatabase.py`
+
 4.2) Replace the values in the `CONFIG` dictionary to reflect the values necessary to connect to the database
+
 4.3) Replace the value of the variable `file_path_books` with the path to the output file from step 3
+
 4.4) Run the `importJsonToDatabase.py` script with the command `python3 importJsonToDatabase.py`
 
 ### Step 5: Import necessary authors into the database
+
 5.1) Open the file `/HuskyReads/back-end/scripts/importAuthors.py`
+
 5.2) Replace the value of the variable `file_path_books` with the path to the output file from step 3
+
 5.3) Run the `importAuthors.py` script with the command `python3 importAuthors.py`

--- a/back-end/scripts/importInstructions.md
+++ b/back-end/scripts/importInstructions.md
@@ -1,0 +1,29 @@
+## <span style="color:deepskyblue">How to import data into the database</span>
+---
+### Step 1: Download raw book data
+
+1.1) Go to [Open Library's data dump page](https://openlibrary.org/developers/dumps) and download the **works dump**
+1.2) Unzip the file if it zipped
+<!-- DELETE THI S1.2) Place the file into `/HuskyReads/back-end/data/raw` and unzip it if it is zipped -->
+
+### Step 2: Clean book Data
+2.1) Open the file `/HuskyReads/back-end/scripts/convertFileToCSV.py`
+2.2) Replace the text `INPUT_FILE_PATH` with the absolute path to the text file from step 1
+2.3) Replace the text `OUTPUT_FILE_PATH` with the absolute path of the file you would like to write to. This file should be placed into the folder `HuskyReads/back-end/data/raw`
+**Note:** Make sure a file with the path `OUTPUT_FILE_PATH` doesn't already exist.
+2.4) Open a command line/terminal window and change your current directory to the `/HuskyReads/back-end/scripts` directory
+2.4) Run the `convertFileToCSV.py` script with the command `python3 convertFileToCSV.py`
+
+### Step 3: Turn the book data into JSON
+3.1) Run the `createJsonFile.py` script with the command `python3 createJsonFile.py`
+
+### Step 4: Import the JSON book data in the database
+4.1) Open the file `/HuskyReads/back-end/scripts/importJsonToDatabase.py`
+4.2) Replace the values in the `CONFIG` dictionary to reflect the values necessary to connect to the database
+4.3) Replace the value of the variable `file_path_books` with the path to the output file from step 3
+4.4) Run the `importJsonToDatabase.py` script with the command `python3 importJsonToDatabase.py`
+
+### Step 5: Import necessary authors into the database
+5.1) Open the file `/HuskyReads/back-end/scripts/importAuthors.py`
+5.2) Replace the value of the variable `file_path_books` with the path to the output file from step 3
+5.3) Run the `importAuthors.py` script with the command `python3 importAuthors.py`

--- a/back-end/scripts/importJsonToDatabase.py
+++ b/back-end/scripts/importJsonToDatabase.py
@@ -128,7 +128,7 @@ def insertBookData(books: list, cnx: object):
                 cursor.execute(query, values)
         # Insert author references into Book_Authors table
         if book[3] is not None:
-            authorID = book[3][9:]
+            authorID = book[3].split("/")[2]
             query = "INSERT INTO Book_Authors (ISBN_book, id_author) VALUES (%s, %s)"
             values = (book[1], authorID)
             cursor.execute(query, values)

--- a/back-end/scripts/importJsonToDatabase.py
+++ b/back-end/scripts/importJsonToDatabase.py
@@ -159,13 +159,13 @@ def insertAuthorData(authors: list, cnx: object):
 
 def main():
     file_path_books = "../data/processed/sample_data.json"
-    file_path_authors = "../data/processed/sample_author_data.json"
+    # file_path_authors = "../data/processed/sample_author_data.json"
     books = retrieveBookData(file_path_books)
-    authors = retrieveAuthorData(file_path_authors)
+    # authors = retrieveAuthorData(file_path_authors)
     cnx = connectToDatabase()
     print("Connection Successful!")
     insertBookData(books, cnx)
-    insertAuthorData(authors, cnx)
+    # insertAuthorData(authors, cnx)
     print("Data import successful! Please refresh database")
     cnx.close()
 


### PR DESCRIPTION
This pull request creates a script to import authors into our database. It only imports authors that authored books in the input file. In addition, this PR also documents the steps that must be taken in order to process, and import both author and book data into the database. 

Data is correctly imported into the database but our endpoints do **not** return this data to the client. I will write issues for this problem but in short, our use of inner joins in the endpoint SQL statements doesn't include these new books since they don't all have authors or genre data.

closes #141 